### PR TITLE
Add landing page with tool selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# YouTube Quiz Generator
+# AI Tools Hub
 
-A Streamlit app that takes a YouTube video URL, fetches its transcript, summarizes it via OpenAI, and generates a multiple-choice quiz.
+This Streamlit app now starts with a simple landing page that lets you select from multiple tools. The main tool is the **YouTube Quiz Generator** which takes a YouTube video URL, fetches its transcript, summarizes it via OpenAI, and generates a multiple-choice quiz. Each tool page provides a button to return to the home screen.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- introduce a landing page with logo placeholder and dummy tools
- wrap existing quiz generator UI in a function
- add simple router to switch between pages
- update README to mention the new landing page
- ensure logo renders across Streamlit versions

## Testing
- `python -m py_compile streamlit_app.py`
- `python streamlit_app.py` *(fails: FileNotFoundError: No secrets files found)*

------
https://chatgpt.com/codex/tasks/task_e_68405148a5f8832e8c2f980e0937ed9c